### PR TITLE
Hammerhead: Use Pantone hex value for alpha base

### DIFF
--- a/src/config/colorways/colorway_hammerhead.json
+++ b/src/config/colorways/colorway_hammerhead.json
@@ -1,10 +1,10 @@
 {
   "id": "hammerhead",
   "label": "Hammerhead",
-  "manufacturer": "",
+  "manufacturer": "Keylabs",
   "swatches": {
     "base": {
-      "background": "#1f2a44",
+      "background": "#202A44",
       "color": "#49c5b1"
     },
     "mods": {


### PR DESCRIPTION
It looks like the original hex values were obtained by using a color picker on the keyset's homepage. Pantone reports different hex values:

https://www.pantone.com/color-finder/533-C