### PR TITLE
Add amalfi, blacklight and night sakura colorways

### DIFF
--- a/src/config/colorways/colorway_amalfi.json
+++ b/src/config/colorways/colorway_amalfi.json
@@ -1,0 +1,29 @@
+{
+  "id": "amalfi",
+  "label": "Amalfi",
+  "manufacturer": "Infinikey",
+  "designer": "NathanAlphaMan",
+  "swatches": {
+    "base": {
+      "background": "#98C1D2",
+      "color": "#F6FCFE"
+    },
+    "mods": {
+      "background": "#F6FCFE",
+      "color": "#98C1D2"
+    },
+    "accent": {
+      "background": "#EA7D78",
+      "color": "#F6FCFE"
+    }
+  },
+  "override": {
+    "KC_ENT": "accent",
+    "KC_ESC": "accent",
+    "KC_GESC": "accent",
+    "KC_F5": "mods",
+    "KC_F6": "mods",
+    "KC_F7": "mods",
+    "KC_F8": "mods"
+  }
+}

--- a/src/config/colorways/colorway_blacklight.json
+++ b/src/config/colorways/colorway_blacklight.json
@@ -1,0 +1,28 @@
+{
+  "id": "blacklight",
+  "label": "Blacklight",
+  "manufacturer": "Infinikey",
+  "designer": "Ulliam",
+  "swatches": {
+    "base": {
+      "background": "#23262C",
+      "color": "#77659F"
+    },
+    "mods": {
+      "background": "#23262C",
+      "color": "#60BECD"
+    },
+    "accent": {
+      "background": "#23262C",
+      "color": "#60BECD"
+    }
+  },
+  "override": {
+    "KC_ENT": "accent",
+    "KC_ESC": "accent",
+    "KC_F5": "mods",
+    "KC_F6": "mods",
+    "KC_F7": "mods",
+    "KC_F8": "mods"
+  }
+}

--- a/src/config/colorways/colorway_night_sakura.json
+++ b/src/config/colorways/colorway_night_sakura.json
@@ -1,0 +1,30 @@
+{
+  "id": "night_sakura",
+  "label": "夜桜 NightSakura",
+  "manufacturer": "JTK",
+  "designer": "rifen",
+  "swatches": {
+    "base": {
+      "background": "#41414e",
+      "color": "#b08d91"
+    },
+    "mods": {
+      "background": "#27262b",
+      "color": "#b08d91"
+    },
+    "accent": {
+      "background": "#27262b",
+      "color": "#b08d91"
+    }
+  },
+  "override": {
+    "KC_ENT": "accent",
+    "KC_ESC": "accent",
+    "KC_GESC": "accent",
+    "KC_GRV": "base",
+    "KC_F5": "accent",
+    "KC_F6": "accent",
+    "KC_F7": "accent",
+    "KC_F8": "accent"
+  }
+}

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -1,4 +1,7 @@
 //IMPORT
+import colorway_night_sakura from './colorway_night_sakura.json';
+import colorway_blacklight from './colorway_blacklight.json';
+import colorway_amalfi from './colorway_amalfi.json';
 import colorway_wob from "./colorway_wob.json";
 import colorway_bow from "./colorway_bow.json";
 import colorway_8008 from "./colorway_8008.json";
@@ -55,6 +58,9 @@ import colorway_nuclear_data from "./colorway_nuclear_data.json";
 
 const COLORWAYS = {
   //APPEND
+  night_sakura: colorway_night_sakura,
+  blacklight: colorway_blacklight,
+  amalfi: colorway_amalfi,
   wob: colorway_wob,
   bow: colorway_bow,
   nautilus: colorway_nautilus,


### PR DESCRIPTION
I don't have exact colour codes for these sets.
Mainly went over with a color picker tool with the images available on the GB thread.

Blacklight is probably more accurate due to the graphs posted in the forum thread such as
![image](https://user-images.githubusercontent.com/29188449/99526805-e7ee2a80-29ef-11eb-8c92-6eca0d5c45aa.png)


## Amalfi
https://geekhack.org/index.php?topic=108093.0
![image](https://user-images.githubusercontent.com/29188449/99527073-5206cf80-29f0-11eb-8bd0-3ba810a59625.png)
![image](https://user-images.githubusercontent.com/29188449/99527137-69de5380-29f0-11eb-8b59-7c8adc092f04.png)



## Blacklight
https://geekhack.org/index.php?topic=108557.0
![image](https://user-images.githubusercontent.com/29188449/99526914-123fe800-29f0-11eb-92e3-a72116f549af.png)
![image](https://user-images.githubusercontent.com/29188449/99526924-1966f600-29f0-11eb-83dd-39cc9e58946a.png)


## NightSakura
https://geekhack.org/index.php?topic=107748.0
![image](https://user-images.githubusercontent.com/29188449/99526956-2257c780-29f0-11eb-95da-5ed51fc72b25.png)
![image](https://user-images.githubusercontent.com/29188449/99526981-2d125c80-29f0-11eb-8670-3fb291d48363.png)
