### PR TITLE
Add a colorway for 80082 and fix 8008 colors

### DIFF
--- a/src/config/colorways/colorway_80082.json
+++ b/src/config/colorways/colorway_80082.json
@@ -1,6 +1,6 @@
 {
-  "id": "8008",
-  "label": "8008",
+  "id": "80082",
+  "label": "80082 B100",
   "manufacturer": "",
   "swatches": {
     "base": {
@@ -9,10 +9,10 @@
     },
     "mods": {
       "background": "#2b313f",
-      "color": "#da526e"
+      "color": "#67c4e5"
     },
     "accent": {
-      "background": "#da526e",
+      "background": "#67c4e5",
       "color": "#0e1415"
     }
   },

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -6,6 +6,7 @@ import colorway_amalfi from './colorway_amalfi.json';
 import colorway_wob from "./colorway_wob.json";
 import colorway_bow from "./colorway_bow.json";
 import colorway_8008 from "./colorway_8008.json";
+import colorway_80082 from "./colorway_80082.json";
 import colorway_9009 from "./colorway_9009.json";
 import colorway_bento from "./colorway_bento.json";
 import colorway_olivia from "./colorway_olivia.json";
@@ -67,6 +68,7 @@ const COLORWAYS = {
   bow: colorway_bow,
   nautilus: colorway_nautilus,
   "8008": colorway_8008,
+  "80082": colorway_80082,
   dmg: colorway_dmg,
   night_runner: colorway_night_runner,
   "9009": colorway_9009,


### PR DESCRIPTION
Hi! I wanted to add a colorway for 80082 so I created a `colorway_80082.json` with matching colors. However, as I was looking into the existing colorways, I figured out that the existing 8008 colorway could use some changes as well.

### 80082
![80082](https://user-images.githubusercontent.com/25760992/104056555-8a7f8a00-51a5-11eb-89a2-ce63c007422e.png)

#### Proposed colorway:
![new](https://user-images.githubusercontent.com/25760992/104056580-95d2b580-51a5-11eb-8725-b7ca8450381c.png)

### 8008 (Existing colorway)
![8008](https://user-images.githubusercontent.com/25760992/104056602-9f5c1d80-51a5-11eb-94ff-94e6d0ee3f22.png)

#### Original colorway:
![original](https://user-images.githubusercontent.com/25760992/104056791-e5b17c80-51a5-11eb-8e1d-82d53cb09613.png)

#### Proposed colorway:
![modified](https://user-images.githubusercontent.com/25760992/104056739-cfa3bc00-51a5-11eb-854b-762c9f8772e3.png)
