### PR TITLE
Fix right arrow keymap

### DIFF
--- a/src/config/colorways/colorway_pastel.json
+++ b/src/config/colorways/colorway_pastel.json
@@ -56,7 +56,7 @@
     "KC_MO(3)": "accent3",
 
     "KC_LALT": "accent4",
-    "KC_RIGHT": "accent4",
+    "KC_RGHT": "accent4",
     "KC_F5": "accent4",
     "KC_F6": "accent4",
 

--- a/src/config/keys/groups.json
+++ b/src/config/keys/groups.json
@@ -125,7 +125,7 @@
     "KC_PAUS"
   ],
   "nav": ["KC_INS", "KC_DEL", "KC_HOME", "KC_END", "KC_PGUP", "KC_PGDN"],
-  "arrows": ["KC_LEFT", "KC_RIGHT", "KC_DOWN", "KC_UP"],
+  "arrows": ["KC_LEFT", "KC_RGHT", "KC_DOWN", "KC_UP"],
   "stabilized": ["KC_BSPC", "KC_ENT", "KC_LSFT", "KC_RSFT", "KC_SPC"],
   "blank": ["KC_SPC"]
 }


### PR DESCRIPTION

Currently, there is a bug where some right arrow keys are written as `KC_RIGHT` (in `src/config/keys/groups.json` and `src/config/colorways/colorway_pastel.json`) whereas others are written as `KC_RGHT`.

This results in a bug where the right arrow override for Pastel colorway would not work as expected.
I found this out while I was experimenting with the arrow overrides when I was creating a new colorway for GMK Shoko (thus, my previous PR to add a Shoko colorway ended up not containing the overrides for the arrow keys.)

The change maps the right arrow properly so that the overrides would work for Pastel, and future colorways that might use right arrow overrides.

### Before
![download (1)](https://user-images.githubusercontent.com/25760992/104084777-fc37f200-51fe-11eb-9e62-fd5b02c26755.png)

### After
![download](https://user-images.githubusercontent.com/25760992/104084778-00fca600-51ff-11eb-90f8-bd5966cc9f12.png)

### Snippet from the original code:

```
    "KC_LALT": "accent4",
    "KC_RIGHT": "accent4", // Should change to KC_RGHT. accent4 here is orange
```