### PR TITLE
Add sublegend editing function

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,5 +1,5 @@
 //spacing / pading
-$sidebar-width: 20em;
+$sidebar-width: 24em;
 $sidebar-padding: 1em;
 $scrollbar-width: 1em;
 $control-width: 5em;

--- a/src/components/colorway/Swatch.js
+++ b/src/components/colorway/Swatch.js
@@ -4,7 +4,7 @@ import styles from "./Swatch.module.scss";
 import ColorPicker from "../elements/ColorPicker";
 
 export default function Swatch(props) {
-  const handelChange = (value, key) => {
+  const handleChange = (value, key) => {
     let newSwatch = { ...props.swatch };
     newSwatch[key] = value.hex;
     props.handler(props.name, newSwatch);
@@ -51,7 +51,7 @@ export default function Swatch(props) {
             label="Background"
             color={props.swatch.background}
             handler={(color) => {
-              handelChange(color, "background");
+              handleChange(color, "background");
             }}
           />
         </div>
@@ -62,10 +62,23 @@ export default function Swatch(props) {
             label="Legend"
             color={props.swatch.color}
             handler={(color) => {
-              handelChange(color, "color");
+              handleChange(color, "color");
             }}
           />
         </div>
+
+        {(props.name === "base" || props.name.match("swatch-")) && (
+          <div className={styles.color}>
+            <ColorPicker
+              isSwatch={true}
+              label="Sublegend"
+              color={props.swatch.subColor ?? props.swatch.color}
+              handler={(color) => {
+                handleChange(color, "subColor");
+              }}
+            />
+          </div>
+        )}
       </div>
     </li>
   );

--- a/src/components/colorway/Swatch.module.scss
+++ b/src/components/colorway/Swatch.module.scss
@@ -4,7 +4,7 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   margin-bottom: 1em;
   border-radius: $primary-border-radius;
   border: 1px solid transparent;
@@ -15,6 +15,7 @@
     font-size: 16px;
     color: var(--light-3);
     text-transform: capitalize;
+    justify-content: center;
   }
   button {
     padding-bottom: 0 !important;
@@ -47,4 +48,5 @@
   padding: 0 0.75em;
   display: flex;
   flex-direction: column;
+  width: 95px;
 }

--- a/src/three/key/key.js
+++ b/src/three/key/key.js
@@ -116,6 +116,10 @@ export class Key {
   get foregroundColor() {
     return this.swatch.color;
   }
+  // color of sublegend on cap
+  get subLegendColor() {
+    return this.swatch.subColor;
+  }
   // get the color group for this key (base, mods, accent, etc)
   get swatch() {
     let group =
@@ -139,6 +143,7 @@ export class Key {
       legend: this.legend,
       code: this.options.code,
       color: this.foregroundColor,
+      subColor: this.subLegendColor,
       background: this.backgroundColor,
       isIsoEnt: this.is_iso_enter,
     };


### PR DESCRIPTION
Adds sublegend editing functionality for base and added swatches, to support increasing trend of triple-shot colorways.
May need to edit docs to mention the additional `subColor` property in swatches when creating custom colorway json?


![Screen Shot 2022-03-25 at 1 44 18 am](https://user-images.githubusercontent.com/33256994/159942252-b875c4e8-e9a4-485f-b25a-a4aec37fa966.png)
