### PR TITLE
Add GMK Sandstorm and GMK Dracula colorways

### DIFF
--- a/src/config/colorways/colorway_dracula.json
+++ b/src/config/colorways/colorway_dracula.json
@@ -1,0 +1,58 @@
+{
+  "id": "dracula",
+  "label": "Dracula",
+  "manufacturer": "GMK",
+  "designer": "pikku-allu",
+  "swatches": {
+    "base": {
+      "background": "#44475a",
+      "color": "#f8f8f2"
+    },
+    "mods": {
+      "background": "#282a36",
+      "color": "#f8f8f2"
+    },
+    "accent": {
+      "background": "#282a36",
+      "color": "#f8f8f2"
+    },
+    "swatch-1": {
+      "background": "#282a36",
+      "color": "#ff79c6"
+    },
+    "swatch-2": {
+      "background": "#282a36",
+      "color": "#bd93f9"
+    },
+    "swatch-3": {
+      "background": "#282a36",
+      "color": "#8be9fd"
+    },
+    "swatch-4": {
+      "background": "#282a36",
+      "color": "#f1fa8c"
+    },
+    "swatch-5": {
+      "background": "#282a36",
+      "color": "#50fa7b"
+    },
+    "swatch-6": {
+      "background": "#282a36",
+      "color": "#ff5555"
+    }
+  },
+  "override": {
+    "KC_ENT": "swatch-2",
+    "KC_ESC": "accent",
+    "KC_GESC": "swatch-3",
+    "KC_TAB": "swatch-1",
+    "KC_RSFT": "swatch-3",
+    "KC_LSFT": "swatch-3",
+    "KC_CAPS": "swatch-2",
+    "KC_LALT": "swatch-2",
+    "KC_LCTL": "swatch-4",
+    "KC_RALT": "swatch-2",
+    "KC_RCTL": "swatch-4",
+    "KC_BSPC": "swatch-1"
+  }
+}

--- a/src/config/colorways/colorway_sandstorm.json
+++ b/src/config/colorways/colorway_sandstorm.json
@@ -1,0 +1,21 @@
+{
+  "id": "sandstorm",
+  "label": "Sandstorm",
+  "manufacturer": "GMK",
+  "designer": "Zambumon",
+  "swatches": {
+    "base": {
+      "background": "#b3a17b",
+      "color": "#dcddcf"
+    },
+    "mods": {
+      "background": "#b3a17b",
+      "color": "#dcddcf"
+    },
+    "accent": {
+      "background": "#f7f2ea",
+      "color": "#171718"
+    },
+    "override": {}
+  }
+}

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -1,4 +1,5 @@
 //IMPORT
+import colorway_sandstorm from './colorway_sandstorm.json';
 import colorway_aurora_polaris from "./colorway_aurora_polaris.json";
 import colorway_port from "./colorway_port.json";
 import colorway_night_sakura from "./colorway_night_sakura.json";
@@ -73,6 +74,7 @@ import colorway_pluto from "./colorway_pluto.json";
 
 const COLORWAYS = {
   //APPEND
+'sandstorm': colorway_sandstorm,
   aurora_polaris: colorway_aurora_polaris,
   port: colorway_port,
   night_sakura: colorway_night_sakura,

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -1,5 +1,6 @@
 //IMPORT
-import colorway_sandstorm from './colorway_sandstorm.json';
+import colorway_dracula from "./colorway_dracula.json";
+import colorway_sandstorm from "./colorway_sandstorm.json";
 import colorway_aurora_polaris from "./colorway_aurora_polaris.json";
 import colorway_port from "./colorway_port.json";
 import colorway_night_sakura from "./colorway_night_sakura.json";
@@ -74,7 +75,8 @@ import colorway_pluto from "./colorway_pluto.json";
 
 const COLORWAYS = {
   //APPEND
-'sandstorm': colorway_sandstorm,
+  dracula: colorway_dracula,
+  sandstorm: colorway_sandstorm,
   aurora_polaris: colorway_aurora_polaris,
   port: colorway_port,
   night_sakura: colorway_night_sakura,
@@ -145,7 +147,7 @@ const COLORWAYS = {
   nuclear_data: colorway_nuclear_data,
   finer_things: colorway_finer_things,
   gregory: colorway_gregory,
-  pluto: colorway_pluto,
+  pluto: colorway_pluto
 };
 
 export default COLORWAYS;

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -75,8 +75,6 @@ import colorway_pluto from "./colorway_pluto.json";
 
 const COLORWAYS = {
   //APPEND
-  dracula: colorway_dracula,
-  sandstorm: colorway_sandstorm,
   aurora_polaris: colorway_aurora_polaris,
   port: colorway_port,
   night_sakura: colorway_night_sakura,
@@ -147,7 +145,9 @@ const COLORWAYS = {
   nuclear_data: colorway_nuclear_data,
   finer_things: colorway_finer_things,
   gregory: colorway_gregory,
-  pluto: colorway_pluto
+  pluto: colorway_pluto,
+  dracula: colorway_dracula,
+  sandstorm: colorway_sandstorm,
 };
 
 export default COLORWAYS;


### PR DESCRIPTION
# GMK Sandstorm
![image](https://user-images.githubusercontent.com/15166670/165482793-aaadd1cb-081a-45b1-9d16-dff535ef76e8.png)

No official color codes were provided in the [IC](https://geekhack.org/index.php?topic=99226.0) or [GB](https://geekhack.org/index.php?topic=102364.0#:~:text=Inspired%20by%20cerakoted%20keyboards%20and,love%20to%20have%20a%20beige) threads so an eye drop color picker on the renders was used.

# GMK Dracula 
![image](https://user-images.githubusercontent.com/15166670/165483090-d11b58f2-dea8-43fb-8ab9-787ea5e4e567.png)

Used the official colors provided in the [GB](https://geekhack.org/index.php?topic=102772.0) thread:
![image](https://user-images.githubusercontent.com/15166670/165483280-26a2471d-17be-47c9-87be-3690cb55cd5d.png)
