### PR TITLE
Adding British Racing Green colorway

### DIFF
--- a/src/config/colorways/colorway_britishracing.json
+++ b/src/config/colorways/colorway_britishracing.json
@@ -1,0 +1,31 @@
+{
+  "id": "britishracing",
+  "label": "British Racing Green",
+  "manufacturer": "GMK",
+  "designer": "Lewis Flude",
+  "swatches": {
+    "base": {
+      "background": "#CECBC3",
+      "color": "#1C2F26"
+    },
+    "mods": {
+      "background": "#1C2F26",
+      "color": "#968161"
+    },
+    "accent": {
+      "background": "#968161",
+      "color": "#1C2F26"
+    }
+  },
+  "override": {
+    "KC_SPC": "base",
+    "KC_ENT": "accent",
+    "KC_PENT": "accent",
+    "KC_ESC": "accent",
+    "KC_GESC": "accent",
+    "KC_F5": "mods",
+    "KC_F6": "mods",
+    "KC_F7": "mods",
+    "KC_F8": "mods"
+  }
+}

--- a/src/config/colorways/colorways.js
+++ b/src/config/colorways/colorways.js
@@ -70,6 +70,7 @@ import colorway_nuclear_data from "./colorway_nuclear_data.json";
 import colorway_finer_things from "./colorway_finer_things.json";
 import colorway_gregory from "./colorway_gregory.json";
 import colorway_pluto from "./colorway_pluto.json";
+import colorway_britishracing from "./colorway_britishracing.json";
 
 const COLORWAYS = {
   //APPEND
@@ -144,6 +145,7 @@ const COLORWAYS = {
   finer_things: colorway_finer_things,
   gregory: colorway_gregory,
   pluto: colorway_pluto,
+  britishracing: colorway_britishracing,
 };
 
 export default COLORWAYS;


### PR DESCRIPTION
![brg](https://user-images.githubusercontent.com/62868183/209439296-2df5a242-b14c-46cc-9cc9-325379ce0761.png)

Primarily reflects both the [GMK](https://cannonkeys.com/products/gb-gmk-british-racing-green-brg) and the [NicePBT](https://cannonkeys.com/products/nicepbt-british-racing-green) sets.